### PR TITLE
Add gitlab-runner user

### DIFF
--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update \
     \
     && rm -r /var/lib/apt/lists/*
 
+# Add gitlab-runner user (UID/GID = 996/996 as per host machine)
+RUN groupadd -g 996 gitlab-runner \
+    && useradd --uid 996 --gid 996 --create-home --shell /bin/bash gitlab-runner
+
 # Install OpenJDK
 RUN set -eux; \
     curl -LfsSo /tmp/openjdk.tar.gz ${OPEN_JDK_DOWNLOAD_URL}; \

--- a/CorrettoJDK.Dockerfile
+++ b/CorrettoJDK.Dockerfile
@@ -3,5 +3,5 @@ FROM amazoncorretto:8u292-alpine
 RUN apk update && apk add bash git && rm -Rf /var/cache/apk/*
 
 # Add gitlab-runner user (UID/GID = 996/996 as per host machine)
-RUN groupadd -g 996 gitlab-runner \
-    && useradd --uid 996 --gid 996 --create-home --shell /bin/bash gitlab-runner
+RUN addgroup -g 996 -S gitlab-runner \
+    && adduser -h /home/gitlab-runner -u 996 -G gitlab-runner -D -s /bin/bash gitlab-runner

--- a/CorrettoJDK.Dockerfile
+++ b/CorrettoJDK.Dockerfile
@@ -1,3 +1,7 @@
 FROM amazoncorretto:8u292-alpine
 
 RUN apk update && apk add bash git && rm -Rf /var/cache/apk/*
+
+# Add gitlab-runner user (UID/GID = 996/996 as per host machine)
+RUN groupadd -g 996 gitlab-runner \
+    && useradd --uid 996 --gid 996 --create-home --shell /bin/bash gitlab-runner

--- a/Ruby.Dockerfile
+++ b/Ruby.Dockerfile
@@ -25,3 +25,7 @@ RUN gem install --no-document \
 RUN apk add --no-cache --update npm \
     && npm i -g codecoach \
     && rm -Rf /var/cache/apk/*
+
+# Add gitlab-runner user (UID/GID = 996/996 as per host machine)
+RUN groupadd -g 996 gitlab-runner \
+    && useradd --uid 996 --gid 996 --create-home --shell /bin/bash gitlab-runner

--- a/Ruby.Dockerfile
+++ b/Ruby.Dockerfile
@@ -27,5 +27,5 @@ RUN apk add --no-cache --update npm \
     && rm -Rf /var/cache/apk/*
 
 # Add gitlab-runner user (UID/GID = 996/996 as per host machine)
-RUN groupadd -g 996 gitlab-runner \
-    && useradd --uid 996 --gid 996 --create-home --shell /bin/bash gitlab-runner
+RUN addgroup -g 996 -S gitlab-runner \
+    && adduser -h /home/gitlab-runner -u 996 -G gitlab-runner -D -s /bin/bash gitlab-runner


### PR DESCRIPTION
Create a user in the container with the same UID/GID as the `gitlab-runner` user that GitLab uses to run the builds. Running containers on the shell executor with this user will avoid permissions issues with generated files.