### PR TITLE
Add AGP 7.0.1 support

### DIFF
--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -1,17 +1,16 @@
 FROM ubuntu:18.04
 
-ARG ANDROID_COMPILE_SDK='29'
-ARG ANDROID_BUILD_TOOLS='28.0.3'
-ARG ANDROID_SDK_TOOLS='6200805'
-ARG OPEN_JDK_DOWNLOAD_URL='https://corretto.aws/downloads/resources/8.292.10.1/amazon-corretto-8.292.10.1-linux-x64.tar.gz'
-ARG OPEN_JDK_MD5='9d711fdeb9176a96bae0ba276f3f3695'
+ARG ANDROID_COMPILE_SDK='30'
+ARG ANDROID_BUILD_TOOLS='30.0.2'
+ARG ANDROID_SDK_TOOLS='7302050'
+ARG OPEN_JDK_DOWNLOAD_URL='https://corretto.aws/downloads/resources/11.0.12.7.1/amazon-corretto-11.0.12.7.1-linux-x64.tar.gz'
+ARG OPEN_JDK_MD5='55e5ca4565737598ff24c6d927253275'
 
 ENV LANG='en_US.UTF-8'
 ENV LANGUAGE='en_US:en'
 ENV JAVA_HOME=/opt/java/openjdk
-ENV JRE_HOME=/opt/java/openjdk/jre
 ENV ANDROID_HOME=/opt/android-sdk-linux
-ENV PATH="/opt/android-sdk-linux/tools:/opt/android-sdk-linux/platform-tools:/opt/android-sdk-linux/tools/bin:/opt/java/openjdk/bin:$PATH"
+ENV PATH="/opt/android-sdk-linux/cmdline-tools:/opt/android-sdk-linux/platform-tools:/opt/android-sdk-linux/cmdline-tools/bin:/opt/java/openjdk/bin:$PATH"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -37,10 +36,10 @@ RUN set -eux; \
     chown -R root:root /opt/java; \
     rm -rf /tmp/openjdk.tar.gz; \
     \
-    update-alternatives --install /usr/bin/java java ${JRE_HOME}/bin/java 1 \
-    && update-alternatives --set java ${JRE_HOME}/bin/java \
-    && update-alternatives --install /usr/bin/javac javac ${JRE_HOME}/../bin/javac 1 \
-    && update-alternatives --set javac ${JRE_HOME}/../bin/javac
+    update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 1 \
+    && update-alternatives --set java ${JAVA_HOME}/bin/java \
+    && update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 1 \
+    && update-alternatives --set javac ${JAVA_HOME}/bin/javac
 
 # Install Android SDK
 RUN curl -L https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip > /tmp/android-sdk-linux.zip \

--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -36,20 +36,20 @@ RUN set -eux; \
     chown -R root:root /opt/java; \
     rm -rf /tmp/openjdk.tar.gz; \
     \
-    update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 1 \
-    && update-alternatives --set java ${JAVA_HOME}/bin/java \
-    && update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 1 \
-    && update-alternatives --set javac ${JAVA_HOME}/bin/javac
+    update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 1 \
+    && update-alternatives --set java "${JAVA_HOME}/bin/java" \
+    && update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 1 \
+    && update-alternatives --set javac "${JAVA_HOME}/bin/javac"
 
 # Install Android SDK
 RUN curl -L https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip > /tmp/android-sdk-linux.zip \
-    && unzip -q /tmp/android-sdk-linux.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools/ \
+    && unzip -q /tmp/android-sdk-linux.zip -d "${ANDROID_SDK_ROOT}/cmdline-tools/" \
     && rm /tmp/android-sdk-linux.zip \
-    && mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools \
+    && mv "${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools" "${ANDROID_SDK_ROOT}/cmdline-tools/tools" \
     \
     && yes | sdkmanager --no_https --licenses \
     && sdkmanager platform-tools --verbose \
         "platforms;android-${ANDROID_COMPILE_SDK}" \
         "build-tools;${ANDROID_BUILD_TOOLS}" \
     \
-    && rm -r ${ANDROID_SDK_ROOT}/emulator
+    && rm -r "${ANDROID_SDK_ROOT}/emulator"

--- a/Build.Dockerfile
+++ b/Build.Dockerfile
@@ -9,8 +9,8 @@ ARG OPEN_JDK_MD5='55e5ca4565737598ff24c6d927253275'
 ENV LANG='en_US.UTF-8'
 ENV LANGUAGE='en_US:en'
 ENV JAVA_HOME=/opt/java/openjdk
-ENV ANDROID_HOME=/opt/android-sdk-linux
-ENV PATH="/opt/android-sdk-linux/cmdline-tools:/opt/android-sdk-linux/platform-tools:/opt/android-sdk-linux/cmdline-tools/bin:/opt/java/openjdk/bin:$PATH"
+ENV ANDROID_SDK_ROOT=/opt
+ENV PATH="/opt/cmdline-tools/tools/bin:/opt/platform-tools:/opt/java/openjdk/bin:$PATH"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -43,13 +43,13 @@ RUN set -eux; \
 
 # Install Android SDK
 RUN curl -L https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip > /tmp/android-sdk-linux.zip \
-    && unzip /tmp/android-sdk-linux.zip -d /opt/android-sdk-linux/ \
+    && unzip -q /tmp/android-sdk-linux.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools/ \
     && rm /tmp/android-sdk-linux.zip \
+    && mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools \
     \
-    && yes | sdkmanager --no_https --licenses --sdk_root=${ANDROID_HOME} \
-    && sdkmanager --sdk_root=${ANDROID_HOME} --verbose tools platform-tools \
-      "platforms;android-${ANDROID_COMPILE_SDK}" \
-      "build-tools;${ANDROID_BUILD_TOOLS}" \
+    && yes | sdkmanager --no_https --licenses \
+    && sdkmanager platform-tools --verbose \
+        "platforms;android-${ANDROID_COMPILE_SDK}" \
+        "build-tools;${ANDROID_BUILD_TOOLS}" \
     \
-    && rm -r ${ANDROID_HOME}/emulator \
-    && unset ANDROID_NDK_HOME
+    && rm -r ${ANDROID_SDK_ROOT}/emulator


### PR DESCRIPTION
JVM 11 and build tools 30.0.2 are required to migrate to Android gradle plugin 7.0.1.
https://developer.android.com/studio/releases/gradle-plugin#7-0-0
![image](https://user-images.githubusercontent.com/4246721/132161327-3848b86c-283d-4fd9-acc6-adbffcfb9fa5.png)

